### PR TITLE
fix line number starting on previous line

### DIFF
--- a/src/clone.ts
+++ b/src/clone.ts
@@ -219,6 +219,9 @@ async function main(
         }
 
         if (doc) {
+          // fix new line number starting on previous line
+          if (!onePdfPerFile && fileCount > 1) doc.text("\n");
+          
           if (isBinaryFileSync(filePath)) {
             const data = fs.readFileSync(filePath).toString("base64");
             if (fileCount > 1) doc.addPage();


### PR DESCRIPTION
<img width="348" height="55" alt="Screenshot 2025-11-06 174153" src="https://github.com/user-attachments/assets/fd6efb27-bdf9-4f83-b76d-30680a690710" />
<img width="276" height="52" alt="Screenshot 2025-11-06 173752" src="https://github.com/user-attachments/assets/f4aa6455-51bb-459b-b674-2562f59b5d77" />

This shows a before and after of the line number fix.