### PR TITLE
fix extra page bug by closing page flow

### DIFF
--- a/src/clone.ts
+++ b/src/clone.ts
@@ -130,6 +130,7 @@ async function main(
 
     if (!onePdfPerFile) {
       if (doc) {
+        doc.text("", { continued: false }); // ensure text flow is closed before adding page numbers
         const pages = doc.bufferedPageRange();
         for (let i = 0; i < pages.count; i++) {
           doc.switchToPage(i);


### PR DESCRIPTION
Fixes first page not being properly numbered and page 1 of N being overflowed as a new page at the end.

Before
<img width="1024" height="720" alt="Screenshot 2025-11-06 174704" src="https://github.com/user-attachments/assets/8184abd7-e18f-42b9-98ef-6c8d113c3962" />

After
<img width="1026" height="133" alt="Screenshot 2025-11-06 182238" src="https://github.com/user-attachments/assets/0427a27b-b0af-40f6-ab15-8a3e10c7f506" />
